### PR TITLE
Track admin via UID

### DIFF
--- a/src/components/CreateRoom.js
+++ b/src/components/CreateRoom.js
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { v4 as uuid } from 'uuid';
-import { db, ref, set } from '../firebase';
+import { db, ref, set, auth } from '../firebase';
 import { useState } from 'react';
 import './CreateRoom.css';
 
@@ -18,9 +18,10 @@ export default function CreateRoom() {
     // Create the room in the database and mark the creator as admin
     set(ref(db, `rooms/${roomId}`), {
       createdAt: new Date().toISOString(),
-      admin: userName
+      admin: userName,
+      adminUid: auth.currentUser.uid,
     }).then(() => {
-      navigate(`/room/${roomId}?admin=${encodeURIComponent(userName)}`);
+      navigate(`/room/${roomId}`);
     });
   };
 

--- a/src/components/PokerRoom.js
+++ b/src/components/PokerRoom.js
@@ -10,7 +10,8 @@ import {
   onDisconnect,
   serverTimestamp,
   auth,
-  setDisplayName
+  setDisplayName,
+  onAuthStateChanged
 } from '../firebase';
 import { QRCodeCanvas } from 'qrcode.react';
 import './PokerRoom.css';
@@ -28,13 +29,22 @@ export default function PokerRoom() {
   const [copied, setCopied] = useState(false);
   const [admin, setAdmin] = useState(null);
   const [adminUid, setAdminUid] = useState(null);
+  const [currentUid, setCurrentUid] = useState(auth.currentUser?.uid || null);
+
+  // Keep track of authentication state
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setCurrentUid(user?.uid || null);
+    });
+    return unsubscribe;
+  }, []);
 
 
   const roomLink = `https://swetha-ganapathy.github.io/planning-poker/#/room/${roomId}`;
   const participantCount = Object.keys(votes).length;
   const activeUserCount = Object.keys(activeUsers).length;
 
-  const isAdmin = auth.currentUser?.uid && adminUid === auth.currentUser.uid;
+  const isAdmin = currentUid && adminUid === currentUid;
 
   // Autofill the admin's name when the authenticated user is the admin
   useEffect(() => {

--- a/src/components/PokerRoom.js
+++ b/src/components/PokerRoom.js
@@ -10,8 +10,7 @@ import {
   onDisconnect,
   serverTimestamp,
   auth,
-  setDisplayName,
-  onAuthStateChanged
+  setDisplayName
 } from '../firebase';
 import { QRCodeCanvas } from 'qrcode.react';
 import './PokerRoom.css';
@@ -20,7 +19,7 @@ const cards = [0.5, 1, 2, 3, 5, 8, '?'];
 
 export default function PokerRoom() {
   const { roomId } = useParams();
-  const [userName, setUserName] = useState(auth.currentUser?.displayName || '');
+  const [userName, setUserName] = useState('');
   const [isRegistered, setIsRegistered] = useState(false);
   const [localVote, setLocalVote] = useState('');
   const [votes, setVotes] = useState({});
@@ -30,21 +29,19 @@ export default function PokerRoom() {
   const [admin, setAdmin] = useState(null);
   const [adminUid, setAdminUid] = useState(null);
 
-  // Populate name from Firebase Auth when available
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      if (user?.displayName && !userName) {
-        setUserName(user.displayName);
-      }
-    });
-    return unsubscribe;
-  }, [userName]);
 
   const roomLink = `https://swetha-ganapathy.github.io/planning-poker/#/room/${roomId}`;
   const participantCount = Object.keys(votes).length;
   const activeUserCount = Object.keys(activeUsers).length;
 
   const isAdmin = auth.currentUser?.uid && adminUid === auth.currentUser.uid;
+
+  // Autofill the admin's name when the authenticated user is the admin
+  useEffect(() => {
+    if (isAdmin && admin && !userName) {
+      setUserName(admin);
+    }
+  }, [isAdmin, admin, userName]);
 
   const getVoteCounts = () => {
     const counts = {};

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -71,5 +71,6 @@ export {
   serverTimestamp,
   get,
   auth,
-  setDisplayName
+  setDisplayName,
+  onAuthStateChanged
 };


### PR DESCRIPTION
## Summary
- include auth when creating a room
- store adminUid in Firebase and navigate without query params
- track adminUid in PokerRoom and compare UIDs for admin rights
- prefill name from Firebase auth when revisiting the room

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f763bd26c832085fed7ad00288e79